### PR TITLE
フォロー機能、フォロー一覧機能作成

### DIFF
--- a/app/assets/javascripts/relationships.coffee
+++ b/app/assets/javascripts/relationships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,35 @@
+class RelationshipsController < ApplicationController
+
+  def index
+    user = User.find(current_user.id)
+    @users = user.followings
+  end
+
+  # フォローするとき
+  def create
+    # user.rbのメソッドを呼び出す
+    current_user.follow(params[:user_id])
+    # 遷移する前のURL（HTTPリファラ）を取得し、リダイレクト
+    redirect_to request.referer
+  end
+
+  # フォロー外すとき
+  def destroy
+    current_user.unfollow(params[:user_id])
+    redirect_to request.referer
+  end
+
+  # フォロー一覧
+  def followings
+    user = User.find(params[:user_id])
+    @users = user.followings
+  end
+
+  # フォロワー一覧
+  def followers
+    user = User.find(params[:user_id])
+    @users = user.followers
+  end
+end
+
+

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,6 @@
+class Relationship < ApplicationRecord
+    # follower、followedはここで定義している
+    # class_name: "User"でUserモデルを参照。フォローする人、フォローされる人を分ける
+    belongs_to :follower, class_name: "User"
+    belongs_to :followed, class_name: "User"
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -21,12 +21,19 @@
                 <% if article.user.image == "default.png" %>
                     <%= image_tag "/user_images/#{article.user.image}", size: '150x150' %>
                 <% else %>
-                    <%= image_tag "/user_images/user_#{article.user.id}.png", size: '150x150' %>
+                    <%= image_tag "/user_images/user_#{article.user_id}.png", size: '150x150' %>
                 <% end %>
+                <div class="content good">
+                    <%# 非同期通信のためのid設定 %>
+                    <p id="article_<%= article.id %>">
+                    <%# 「,」の後ろは、article: で変数を定義している %>
+                        <%= render 'layouts/article', article: article %>
+                    </p>
+                </div>
             </div>
             <div class="name">
                 <p>(名前)</p>
-                <p class="make_a_margin-bottom"><%= article.user.name %></p>
+                <%= link_to article.user.name, user_path(article.user_id) %>
                 <p>(計測日)</p>
                 <p class="make_a_margin-bottom"><%= article.date %></p>
             </div>
@@ -56,13 +63,6 @@
             </div>
         </div>
         <div class="content button_zone">
-            <div class="content good">
-                <%# 非同期通信のためのid設定 %>
-                <p id="article_<%= article.id %>">
-                <%# 「,」の後ろは、article: で変数を定義している %>
-                    <%= render 'layouts/article', article: article %>
-                </p>
-            </div>
             <div class="article_button">
                 <%# アソシエーションのモデルで、idを指定したリンクは引数が2つ必要 %>
                 <%= link_to "詳細", user_article_path(user_id:article.user_id, id:article.id), class: "btn btn-info" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -27,7 +27,7 @@ publicフォルダに画像がある場合は、画像ファイル名のみでOK
 </p>
 
 <p>ニックネーム</p>
-<p><%= @article.user.name %></p>
+<%= link_to @article.user.name, user_path(@article.user_id) %>
 
 <p>計測日</p>
 <p><%= @article.date %></p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
                     <%# アソシエーションのモデルで、idを指定したリンクは引数が2つ必要 %>
                     <li><%= link_to "新規投稿", new_user_article_path(user_id: @current_user.id) %></li>
                     <li><%= link_to "自分の投稿一覧", user_articles_path(user_id: @current_user.id) %></li>
-                    <li><%= link_to "お気に入りユーザー一覧", "#" %></li>
+                    <li><%= link_to "お気に入りユーザー一覧", relationships_path(current_user) %></li>
                     <li><%= link_to "プロフィール", user_path(@current_user.id) %></li>
                     <li><%= link_to "ログアウト", logout_path, method: :delete %></li>
                 <% else %>

--- a/app/views/relationships/_follow_list.html.erb
+++ b/app/views/relationships/_follow_list.html.erb
@@ -1,0 +1,9 @@
+
+<table>
+    <tbody>
+        <tr>
+            <td>フォロー数: <%= user.followings.count %></td>
+            <td>フォロワー数: <%= user.followers.count %></td>
+        </tr>
+    </tbody>
+</table>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -1,0 +1,2 @@
+<h1>Relationships#followers</h1>
+<p>Find me in app/views/relationships/followers.html.erb</p>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -1,0 +1,2 @@
+<h1>Relationships#followings</h1>
+<p>Find me in app/views/relationships/followings.html.erb</p>

--- a/app/views/relationships/index.html.erb
+++ b/app/views/relationships/index.html.erb
@@ -1,0 +1,7 @@
+<h2><%= current_user.name + 'のお気に入り一覧' %></h2>
+
+<% @users.each do |user| %>
+    <P>
+        <%= link_to user.name, user_path(user.id) %>
+    </p>
+<% end %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -10,17 +10,27 @@
 <% @articles.each do |article| %>
     <article>
         <div class="content">
-            <div class="image">
-                <% if article.user.image == "default.png" %>
-                    <%= image_tag "/user_images/#{article.user.image}", size: '150x150' %>
-                <% else %>
-                    <%= image_tag "/user_images/user_#{article.user.id}.png", size: '150x150' %>
-                <% end %>
-                <%= link_to "ユーザーの投稿一覧", user_articles_path(article.user.id), class: "btn btn-info" %>
+            <div>
+                <div class="image">
+                    <% if article.user.image == "default.png" %>
+                        <%= image_tag "/user_images/#{article.user.image}", size: '150x150' %>
+                    <% else %>
+                        <%= image_tag "/user_images/user_#{article.user_id}.png", size: '150x150' %>
+                    <% end %>
+                </div>
+                <%= link_to "ユーザーの投稿一覧", user_articles_path(article.user_id), class: "btn btn-info" %>
+                <div class="content good">
+                    <%# 非同期通信のためのid設定 %>
+                    <p id="article_<%= article.id %>">
+                    <%# 「,」の後ろは、article: で変数を定義している %>
+                        <%= render 'layouts/article', article: article %>
+                    </p>
+                </div>
             </div>
+
             <div class="name">
                 <p>(名前)</p>
-                <p class="make_a_margin-bottom"><%= article.user.name %></p>
+                <%= link_to article.user.name, user_path(article.user_id) %>
                 <p>(計測日)</p>
                 <p class="make_a_margin-bottom"><%= article.date %></p>
             </div>
@@ -51,13 +61,7 @@
             </div>
         </div>
         <div class="content button_zone">
-            <div class="content good">
-                <%# 非同期通信のためのid設定 %>
-                <p id="article_<%= article.id %>">
-                <%# 「,」の後ろは、article: で変数を定義している %>
-                    <%= render 'layouts/article', article: article %>
-                </p>
-            </div>
+
             <div class="article_button">
                 <%# 書き方注意、user_id,idが必要 user_article_path(user_id: article.user_id, id:article.id) %>
                 <%= link_to "詳細", user_article_path(user_id: article.user_id, id:article.id), class: "btn btn-info" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,6 +15,20 @@ publicフォルダに画像がある場合は、画像ファイル名のみでOK
 <p>ニックネーム</p>
 <p><%= @user.name %></p>
 
+<p>
+    <% if current_user %>
+        <% unless current_user.id == @user.id %>
+            <% if current_user.following?(@user) %>
+                <%= link_to "フォロー外す", user_relationships_path(@user.id), method: :delete %>
+            <% else %>
+                <%= link_to "フォローする", user_relationships_path(@user.id), method: :post %>
+            <% end %>
+        <% end %>
+    <% end %>
+</p>
+
+<%= render 'relationships/follow_list', user: @user  %>
+
 <p>自己紹介</p>
 <p><%= @user.self_introduction %></p>
 
@@ -37,12 +51,19 @@ publicフォルダに画像がある場合は、画像ファイル名のみでOK
 <p>***********</p>
 
 <%# ログインしているユーザーIDとプロフィール詳細のユーザーIDが一致する場合、表示できる %>
-<% if logged_in? %>
-    <% if current_user.admin %>
-        <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-info" %>
-        <%= link_to "削除", user_path(@user.id), class: "btn btn-sm btn-danger", method: :delete, data: { confirm: "本当に削除しますか？" } %>
-    <% elsif current_user.id == @user.id %>
-        <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-info" %>
-        <%= link_to "削除", user_path(@user.id), class: "btn btn-sm btn-danger", method: :delete, data: { confirm: "本当に削除しますか？" } %>
+<div>
+    <% if logged_in? %>
+        <% if current_user.admin %>
+            <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-info" %>
+            <%= link_to "削除", user_path(@user.id), class: "btn btn-sm btn-danger", method: :delete, data: { confirm: "本当に削除しますか？" } %>
+        <% elsif current_user.id == @user.id %>
+            <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-info" %>
+            <%= link_to "削除", user_path(@user.id), class: "btn btn-sm btn-danger", method: :delete, data: { confirm: "本当に削除しますか？" } %>
+        <% end %>
     <% end %>
-<% end %>
+</div>
+
+<div>
+    <%= link_to "ユーザーの投稿一覧", user_articles_path(@user.id), class: "btn btn-info" %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'relationships/followings'
+  get 'relationships/followers'
+
   get 'articles/new'
   get 'sessions/new'
   get 'users/new'
@@ -17,8 +20,12 @@ Rails.application.routes.draw do
     resources :articles do
       resources :comments, only: [:create, :destroy]
     end
-    # end
+    resource :relationships, only: [:create, :destroy]
+    get 'followings' => 'relationships#followings', as: 'followings'
+    get 'followers' => 'relationships#followers', as: 'followers'
   end
+
+  resources :relationships, only: [:index]
 
   # ログイン機能
   get    '/login', to: 'sessions#new'

--- a/db/migrate/20230128055512_create_relationships.rb
+++ b/db/migrate/20230128055512_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20230125135935) do
+ActiveRecord::Schema.define(version: 20230128055512) do
 
   create_table "articles", force: :cascade do |t|
     t.integer "user_id"
@@ -39,6 +39,13 @@ ActiveRecord::Schema.define(version: 20230125135935) do
   create_table "likes", force: :cascade do |t|
     t.integer "user_id"
     t.integer "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  test "should get followings" do
+    get relationships_followings_url
+    assert_response :success
+  end
+
+  test "should get followers" do
+    get relationships_followers_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
* 関連するIssueやプルリクエスト

・ユーザーフォロー機能を作成
自分以外のユーザーに対して、ユーザー詳細画面からのみフォロー、フォロー取り消しできる
・お気に入りユーザー一覧の確認
ヘッダーのお気に入りユーザー一覧の確認をクリックすると、自分がお気に入りしているユーザーが一覧化されているページに遷移する

~~{# #} なぜこの変更をするのか~~

~~* 変更をする理由~~
~~* 前提知識がなくても分かるようにする~~

## やったこと

* [x] やったこと
* [ ] やっていること

## 変更内容

* UIの変更ならスクリーンショット

ユーザー詳細画面(自分以外のユーザー、既にフォローしている画面)
<img width="593" alt="image" src="https://user-images.githubusercontent.com/69975275/215276266-3644997f-87f9-47c8-b006-83a1a145175e.png">

お気に入りユーザー一覧
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/69975275/215276257-34c2dcc7-d31d-4362-8853-8797fe57b1f5.png">

~~* APIの変更ならリクエストとレスポンス~~

~~## 影響範囲~~

~~* ユーザに影響すること~~
~~* メンバーに影響すること~~
~~* システムに影響すること~~

~~## どうやるのか~~

~~* 使い方~~
~~* 再現手順~~

~~## 課題~~

~~* 悩んでいること~~
~~* とくにレビューしてほしいところ~~

~~## 備考~~

~~* その他に伝えたいこと~~
