### PR TITLE
誤りがあったのを修正 / articles/index.htmlを表示する時、体重の記載がないものは除くよう変更

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -9,7 +9,7 @@ class ArticlesController < ApplicationController
     if params[:articles]
       @articles = []
       params[:articles].each do |article|
-        new_article = Article.find_by(id: article[:id]).where.not(weight: nil)
+        new_article = Article.find_by(id: article[:id])
         @articles.push(new_article)
       end
 # グラフの年月絞り込みではなく、キーワード検索、日付けでの絞り込み検索の場合の投稿一覧取得


### PR DESCRIPTION
誤りがあったのを修正 / articles/index.htmlを表示する時、体重の記載がないものは除くよう変更

searchメソッドの以下箇所で.where.not(weight: nil)の記載を入れてしまったためエラーになったので、削除。
    if params[:articles]
      @articles = []
      params[:articles].each do |article|
        new_article = Article.find_by(id: article[:id]) # ..where.not(weight: nil)があったのを削除
        @articles.push(new_article)
      end