### PR TITLE
TOPページの投稿表示順を調整

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -10,7 +10,8 @@ class TopController < ApplicationController
     end
 
     def index
-        @articles = Article.all.where.not(weight: nil).order(created_at: "DESC")
+        # 順序はcreated_atだと正しくならない(その月の最初のデータが作成されたときに1ヶ月分のデータが生成されるため)。updated_atにする
+        @articles = Article.all.where.not(weight: nil).order(updated_at: "DESC")
         @comment = Comment.new
     end
 end


### PR DESCRIPTION
Top_controller.rbを修正。
順序はcreated_atだと正しくならない(その月の最初のデータが作成されたときに1ヶ月分のデータが生成されるため)。

